### PR TITLE
Enhance drag-and-drop to visually highlight nodes

### DIFF
--- a/src/components/DraggableTreeNode.tsx
+++ b/src/components/DraggableTreeNode.tsx
@@ -25,18 +25,21 @@ const DraggableTreeNode: React.FC<DraggableTreeNodeProps> = ({
     }),
   });
 
-  const [, drop] = useDrop({
+  const [{ isOver }, drop] = useDrop({
     accept: 'TREE_NODE',
     drop: (item: { node: TreeNode }) => {
       onMoveNode(item.node, node);
     },
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+    }),
   });
 
   return (
     <div
       ref={(instance) => drag(drop(instance))}
       style={{ opacity: isDragging ? 0.5 : 1 }}
-      className={`cursor-pointer p-1 rounded ${selected === node.id ? 'bg-blue-200' : ''}`}
+      className={`cursor-pointer p-1 rounded ${selected === node.id ? 'bg-blue-200' : ''} ${isOver ? 'border border-blue-500' : ''}`}
       onClick={() => onSelect(node)}
     >
       {children}


### PR DESCRIPTION
Enhance drag-and-drop functionality to visually highlight the target node.

* Add `isOver` state to `useDrop` hook to track if a node is being dragged over.
* Add conditional class to highlight the target node with a border when `isOver` is true.
* Update the `drop` function to include `isOver` state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vritb/tree-editor/pull/3?shareId=8df7ab62-a679-4efb-b115-74cd4f8b8934).