### PR TITLE
Fix drag hover indicator for tree nodes

### DIFF
--- a/src/components/DraggableTreeNode.tsx
+++ b/src/components/DraggableTreeNode.tsx
@@ -25,13 +25,14 @@ const DraggableTreeNode: React.FC<DraggableTreeNodeProps> = ({
     }),
   });
 
-  const [{ isOver }, drop] = useDrop({
+  const [{ isOver, isOverCurrent }, drop] = useDrop({
     accept: 'TREE_NODE',
     drop: (item: { node: TreeNode }) => {
       onMoveNode(item.node, node);
     },
     collect: (monitor) => ({
       isOver: monitor.isOver(),
+      isOverCurrent: monitor.isOver({ shallow: true }),
     }),
   });
 
@@ -39,7 +40,7 @@ const DraggableTreeNode: React.FC<DraggableTreeNodeProps> = ({
     <div
       ref={(instance) => drag(drop(instance))}
       style={{ opacity: isDragging ? 0.5 : 1 }}
-      className={`cursor-pointer p-1 rounded ${selected === node.id ? 'bg-blue-200' : ''} ${isOver ? 'border border-blue-500' : ''}`}
+      className={`cursor-pointer p-1 rounded ${selected === node.id ? 'bg-blue-200' : ''} ${isOver ? 'border border-blue-500' : ''} ${isOverCurrent ? 'bg-green-200' : ''}`}
       onClick={() => onSelect(node)}
     >
       {children}


### PR DESCRIPTION
Add visual indication for when a dragged node is directly over a target node.

* Add `isOverCurrent` to the `useDrop` hook to track if the dragged node is directly over the target node.
* Add a conditional class to indicate when a node is ready to accept a new sibling or child by changing the background color to green when `isOverCurrent` is true.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vritb/tree-editor/pull/4?shareId=ada20c00-cc8f-4170-80db-b4fa05e3f812).