### PR TITLE
Add a panel to display undo/redo stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A minimal web application to create, edit and visualize JSON structures as a col
 * Add/remove child nodes dynamically
 * Export the current tree to valid JSON
 * Live statistics (depth, counts per node type)
+* Display the contents of the undo and redo stacks
 
 ## Tech stack
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import SettingsPanel from './components/SettingsPanel';
 import { getUndoRedoDepthLimit } from './config/te-config';
+import UndoRedoPanel from './components/UndoRedoPanel';
 
 const initial: RootNode = parseJsonToTree({})
 
@@ -191,6 +192,7 @@ export default function App() {
             undoRedoDepthLimit={undoRedoDepthLimit}
             setUndoRedoDepthLimit={setUndoRedoDepthLimit}
           />
+          <UndoRedoPanel history={history} redoStack={redoStack} />
         </div>
       </div>
     </DndProvider>

--- a/src/components/UndoRedoPanel.tsx
+++ b/src/components/UndoRedoPanel.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { TreeNode } from '../types/nodes';
+
+interface UndoRedoPanelProps {
+  history: TreeNode[];
+  redoStack: TreeNode[];
+}
+
+const UndoRedoPanel: React.FC<UndoRedoPanelProps> = ({ history, redoStack }) => {
+  return (
+    <div className="undo-redo-panel">
+      <h2 className="font-semibold">Undo/Redo Stack</h2>
+      <div className="mt-2">
+        <h3 className="font-medium">Undo Stack</h3>
+        <ul className="list-disc pl-4">
+          {history.map((state, index) => (
+            <li key={index}>{state.name || '(root)'}</li>
+          ))}
+        </ul>
+      </div>
+      <div className="mt-2">
+        <h3 className="font-medium">Redo Stack</h3>
+        <ul className="list-disc pl-4">
+          {redoStack.map((state, index) => (
+            <li key={index}>{state.name || '(root)'}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default UndoRedoPanel;


### PR DESCRIPTION
Add a panel to display the undo/redo stack.

* **New Component**: Create `UndoRedoPanel` in `src/components/UndoRedoPanel.tsx` to display the undo and redo stacks.
  - Import `React` and necessary types.
  - Define `UndoRedoPanel` component with `history` and `redoStack` props.
  - Render the contents of the undo and redo stacks in a list format.
  - Export the `UndoRedoPanel` component.

* **App Integration**: Update `src/App.tsx` to include the `UndoRedoPanel` component.
  - Import `UndoRedoPanel`.
  - Add `UndoRedoPanel` to the JSX structure.
  - Pass `history` and `redoStack` state variables as props to `UndoRedoPanel`.

* **Documentation**: Update `README.md` to include a description of the new undo/redo stack display feature.
  - Add a bullet point for displaying the contents of the undo and redo stacks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vritb/tree-editor/pull/6?shareId=5574a8b2-3709-4e59-a3b6-df6731e72241).