### PR TITLE
Enhance undo/redo functionality with keyboard shortcuts and visual indicators

### DIFF
--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { DataNode, TreeNode } from '../types/nodes'
 import DraggableTreeNode from './DraggableTreeNode';
 
@@ -8,6 +8,7 @@ interface Props {
   onSelect: (n: TreeNode) => void
   onUpdate: (n: TreeNode) => void
   onMoveNode: (draggedNode: TreeNode, targetNode: TreeNode) => void;
+  highlightedNode?: string | null;
 }
 
 export default function TreeView({
@@ -16,6 +17,7 @@ export default function TreeView({
   onSelect,
   onUpdate,
   onMoveNode,
+  highlightedNode,
 }: Props) {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
 
@@ -49,7 +51,7 @@ export default function TreeView({
           <div
             className={`cursor-pointer p-1 rounded ${
               selected === n.id ? 'bg-blue-200' : ''
-            }`}
+            } ${highlightedNode === n.id ? 'bg-yellow-200' : ''}`}
             onClick={() => onSelect(n)}
           >
             {hasChildren && (


### PR DESCRIPTION
Add keyboard shortcuts for undo/redo actions and highlight changes in the tree view.

* **src/App.tsx**
  - Add `useEffect` to handle keyboard shortcuts for undo (`Ctrl+Z`) and redo (`Ctrl+Y`) actions.
  - Add `highlightedNode` state to track the node affected by undo/redo actions.
  - Update `handleUndo` and `handleRedo` functions to set `highlightedNode` when actions are performed.
  - Pass `highlightedNode` prop to `TreeView` component.

* **src/components/TreeView.tsx**
  - Add `highlightedNode` prop to `TreeView` component.
  - Update node rendering logic to apply a yellow background to the highlighted node.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vritb/tree-editor/pull/11?shareId=3d17045a-07d8-486d-9187-a18e9c85be57).